### PR TITLE
Do not restrict future node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A gulp plugin for generating checksum file.",
   "main": "main.js",
   "engines": {
-    "node": ">=8.0.0 <=12.13.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
Do not restrict future node versions, as breakages from node are very unlikely. 